### PR TITLE
fix(layout):

### DIFF
--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -11,12 +11,6 @@ const StyledHeader = styled.header`
     justify-content: center;
     padding: 4rem 2rem;
   `}
-
-  ${media.desktop`
-    padding: 4rem 8.6rem;
-    flex-direction: row;
-    justify-content: flex-start;
-  `}
 `;
 
 export default StyledHeader;

--- a/src/components/Logo/Logo.styles.ts
+++ b/src/components/Logo/Logo.styles.ts
@@ -6,10 +6,11 @@ export const StyledLink = styled(Link)`
   display: flex;
   align-items: center;
   text-decoration: none;
-  min-width: 30rem;
+  width: 20rem;
   z-index: 1001;
   ${media.phone`
     margin-left: 2rem;
+    width: 30rem;
   `}
   ${media.desktop`
     margin-left: 0;

--- a/src/components/NavBar/NavBar.styles.ts
+++ b/src/components/NavBar/NavBar.styles.ts
@@ -19,8 +19,8 @@ export const StyledUl = styled.ul`
       margin: 0;
       flex-direction: row;
     `}
-  ${media.desktop`
-      margin: 0 4rem;
+    ${media.desktop`
+      margin: 0 0 0 -2rem;
     `}
 `;
 

--- a/src/components/Search/Search.component.tsx
+++ b/src/components/Search/Search.component.tsx
@@ -7,6 +7,7 @@ import getClassName from '../../utils/getClassName';
 import { FOCUSED_CLASS_NAME } from '../../constants/furtherClassNames';
 import Input from './components/Input';
 import HitsWrapper from './components/HitsWrapper';
+import CloseButton from './components/CloseButton';
 
 const Search: React.FC = () => {
   const ref = createRef<HTMLFormElement>();
@@ -17,13 +18,22 @@ const Search: React.FC = () => {
 
   useClickOutside(ref, () => setFocus(false));
 
-  const shouldShowHits = query.query.length > 0 && hits.length > 0 && focus;
+  const {
+    query: { length: queryLength },
+  } = query;
+
+  if (!focus && queryLength) {
+    setQuery({ ...query, query: '' });
+  }
+
+  const shouldShowHits = queryLength > 2 && hits.length > 0 && focus;
   const onSubmit = (event: React.FormEvent<HTMLFormElement>): void => event.preventDefault();
   const className = getClassName('', [{ flag: focus, className: FOCUSED_CLASS_NAME }]);
 
   return (
     <StyledForm {...{ focus, ref, onSubmit, className }}>
       <Input {...{ query, setQuery, setIsSearching, setHits, setFocus, focus }} />
+      {focus && <CloseButton onClick={(): void => setFocus(false)} />}
       {shouldShowHits && <HitsWrapper {...{ hits }} />}
     </StyledForm>
   );

--- a/src/components/Search/Search.styles.ts
+++ b/src/components/Search/Search.styles.ts
@@ -12,21 +12,43 @@ const StyledForm = styled.form`
   top: 50%;
   transform: translate(-100%, -50%);
   background-color: transparent;
-  transition: margin-left 0.3s;
+  transition: all 0.3s;
   z-index: 1002;
+  width: 5.2rem;
 
   &.focused {
     background-color: ${colorLiliac};
+    width: 100%;
+    left: 0;
+    top: 0;
+    transform: none;
+    height: 6rem;
+    margin: 0;
+    border-radius: 0;
   }
+
+  ${media.phone`
+    width: auto;
+    &.focused {
+      width: auto;
+      left: 100%;
+      top: 50%;
+      transform: translate(-100%, -50%);
+      height: auto;
+      margin-left: -6rem;
+      border-radius: 3px;
+    }
+  `}
 
   ${media.tablet`
     transform: translate(-100%, 0);
     top: 4rem;
     margin-left: -2rem;
-  `}
-  ${media.desktop`
-    top: 50%;
-    transform: translate(-100%, -50%);
+    &.focused {
+      top: 4rem;
+      transform: translate(-100%, 0);
+      margin-left: -2rem;
+    }
   `}
 `;
 

--- a/src/components/Search/components/CloseButton/CloseButton.component.tsx
+++ b/src/components/Search/components/CloseButton/CloseButton.component.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { StyledButton } from './CloseButton.styles';
+import CloseButtonComponent from './CloseButton.interfaces';
+
+const CloseButton: CloseButtonComponent = props => <StyledButton {...props} />;
+
+export default CloseButton;

--- a/src/components/Search/components/CloseButton/CloseButton.interfaces.ts
+++ b/src/components/Search/components/CloseButton/CloseButton.interfaces.ts
@@ -1,0 +1,7 @@
+interface CloseButtonProps {
+  onClick: () => void;
+}
+
+type CloseButtonComponent = React.FC<CloseButtonProps>;
+
+export default CloseButtonComponent;

--- a/src/components/Search/components/CloseButton/CloseButton.styles.ts
+++ b/src/components/Search/components/CloseButton/CloseButton.styles.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+import { media, colorWarmPurple } from '../../../../utils/css-utils';
+
+export const StyledButton = styled.button`
+  position: fixed;
+  right: 0;
+  height: 6rem;
+  width: 3.5rem;
+  background-color: transparent;
+  border: none;
+  outline: none;
+
+  &:before,
+  &:after {
+    content: '';
+    position: absolute;
+    left: 0;
+    width: 2rem;
+    height: 0.3rem;
+    display: block;
+    background-color: ${colorWarmPurple};
+  }
+
+  &:before {
+    transform: rotate(45deg);
+  }
+
+  &:after {
+    transform: rotate(-45deg);
+  }
+
+  ${media.phone`
+    display: none;
+  `}
+`;

--- a/src/components/Search/components/CloseButton/index.ts
+++ b/src/components/Search/components/CloseButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CloseButton.component';

--- a/src/components/Search/components/HitsWrapper/HitsWrapper.styles.ts
+++ b/src/components/Search/components/HitsWrapper/HitsWrapper.styles.ts
@@ -2,18 +2,23 @@ import styled from 'styled-components';
 import { media, colorWarmPurple, colorLiliac, colorVividPurple } from '../../../../utils/css-utils';
 
 export const HitsWrapperAnchor = styled.div`
-  position: relative;
-  height: 4rem;
+  position: absolute;
+  top: 4.5rem;
+
+  ${media.phone`
+    position: relative;
+    height: 4rem;
+    top: 0;
+  `}
 `;
 
 export const HitsWrapperContainer = styled.div`
   position: absolute;
   top: 100%;
-  left: 5rem;
-  transform: translateX(-100%);
 
   ${media.phone`
     left: 0;
+    transform: translateX(-100%);
   `}
 `;
 
@@ -49,13 +54,16 @@ export const HitsWrapperUl = styled.ul`
   background-color: ${colorWarmPurple};
   position: relative;
   max-height: 60vh;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   border: 2px solid ${colorWarmPurple};
-  border-radius: 3px;
+  border-radius: 0;
   padding: 1rem;
   width: 100vw;
 
   ${media.phone`
+    border-radius: 3px;
+
     width: 50rem;
   `}
 

--- a/src/components/Search/components/Input/Input.component.tsx
+++ b/src/components/Search/components/Input/Input.component.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { getQuery, searchDelay, searchClient, minCharsNumber } from '../../../../utils/search';
 import useDebounce from '../../../../utils/Debounce';
 import SearchIcon from '../SearchIcon/SearchIcon.component';
-import InputComponent, { GetInputOnChange } from './Input.interfaces';
+import InputComponent, { GetInputOnChange, OnKeyDown } from './Input.interfaces';
 import getClassName from '../../../../utils/getClassName';
 import { FOCUSED_CLASS_NAME } from '../../../../constants/furtherClassNames';
 import { Label, StyledInput } from './Input.styles';
@@ -23,6 +23,13 @@ const Input: InputComponent = ({ setQuery, query, setIsSearching, setHits, setFo
   const onChange = getOnChange(setQuery, setHits);
   const onFocus = (): void => setFocus(true);
 
+  const onKeyDown: OnKeyDown = ({ keyCode, currentTarget }) => {
+    if (keyCode === 27) {
+      setFocus(false);
+      currentTarget.blur();
+    }
+  };
+
   useEffect(() => {
     if (debouncedValue && value.length >= minCharsNumber) {
       setIsSearching(true);
@@ -37,7 +44,7 @@ const Input: InputComponent = ({ setQuery, query, setIsSearching, setHits, setFo
   return (
     <Label>
       <SearchIcon />
-      <StyledInput placeholder="Search..." {...{ value, onChange, onFocus, className }} />
+      <StyledInput placeholder="Search..." {...{ value, onChange, onFocus, className, onKeyDown }} />
     </Label>
   );
 };

--- a/src/components/Search/components/Input/Input.interfaces.ts
+++ b/src/components/Search/components/Input/Input.interfaces.ts
@@ -7,6 +7,7 @@ interface SearchQuery {
 }
 
 export type SetSearchQuery = React.Dispatch<React.SetStateAction<SearchQuery>>;
+export type OnKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => void;
 
 export type GetInputOnChange = (
   setQuery: SetSearchQuery,


### PR DESCRIPTION
- remove replacing `NavBar` in line with `Logo` on desktops
- correct `Logo` `width`
- correct `NavBar` `margin`
- correct `Search` styles for `focused` state on phones
- add component `CloseButton` for closing `Search`
- add the ability to close `Search` by clicking `Escape`
- correct `HitsWrapper` styles